### PR TITLE
Removes click drag array

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ var db = mongoose.connection;
 var strokeSchema = new Schema({
   clickX: Array,
   clickY: Array,
-  clickDrag: Array,
   colour: String,
   fontSize: Number
 })
@@ -38,7 +37,6 @@ app.post('/newstroke', function(req, res) {
   var stroke = new Stroke({
     clickX: req.body.clickX,
     clickY: req.body.clickY,
-    clickDrag: req.body.clickDrag,
     colour: req.body.colour,
     fontSize: req.body.fontSize
   });

--- a/public/src/eventListeners.js
+++ b/public/src/eventListeners.js
@@ -12,7 +12,6 @@ board.addEventListener('mousemove', function(element) {
 board.addEventListener('mouseup', function(element) {
   $.post('/newstroke', {clickX: whiteboard.currentStroke.clickX,
                         clickY: whiteboard.currentStroke.clickY,
-                        clickDrag: whiteboard.currentStroke.clickDrag,
                         colour: whiteboard.currentStroke.colour,
                         fontSize: whiteboard.currentStroke.fontSize})
 

--- a/public/src/stroke.js
+++ b/public/src/stroke.js
@@ -1,15 +1,13 @@
 function Stroke(colour = '#000000', font = 5) {
   this.clickX = []
   this.clickY = []
-  this.clickDrag = []
   this.colour = colour;
   this.fontSize = font;
 }
 
-Stroke.prototype.addClick = function(x, y, drag) {
+Stroke.prototype.addClick = function(x, y) {
   this.clickX.push(x)
   this.clickY.push(y)
-  this.clickDrag.push(drag)
 }
 
 module.exports = Stroke;

--- a/public/src/whiteboard.js
+++ b/public/src/whiteboard.js
@@ -12,7 +12,7 @@ function Whiteboard(context) {
 Whiteboard.prototype.startDrawing = function(e, board) {
   this.currentStroke = new Stroke(this.colour, this.fontSize);
   this.painting = true;
-  this.currentStroke.addClick(e.pageX - board.offsetLeft, e.pageY - board.offsetTop, false);
+  this.currentStroke.addClick(e.pageX - board.offsetLeft, e.pageY - board.offsetTop);
   this.redraw();
 }
 
@@ -35,7 +35,7 @@ Whiteboard.prototype.stopDrawing = function() {
 
 Whiteboard.prototype.keepDrawing = function(e, board) {
   if (this.painting) {
-    this.currentStroke.addClick(e.pageX - board.offsetLeft, e.pageY - board.offsetTop, true);
+    this.currentStroke.addClick(e.pageX - board.offsetLeft, e.pageY - board.offsetTop);
     this.redraw();
   }
 }
@@ -46,14 +46,16 @@ Whiteboard.prototype.redraw = function(stroke) {
   this.context.lineJoin = "round";
 
   if (stroke !== null) {
+    
     this.context.lineWidth = stroke.fontSize;
+
     for (var i=0; i < stroke.clickX.length; i++) {
       this.context.beginPath();
 
-      if (stroke.clickDrag[i] && i) {
-        this.context.moveTo(stroke.clickX[i-1], stroke.clickY[i-1]);
-      } else {
+      if (stroke.clickX.length === 1) {
         this.context.moveTo(stroke.clickX[i]-1, stroke.clickY[i]);
+      } else {
+        this.context.moveTo(stroke.clickX[i-1], stroke.clickY[i-1]);
       }
 
       this.context.lineTo(stroke.clickX[i], stroke.clickY[i]);

--- a/test/canvas/canvasSpec.js
+++ b/test/canvas/canvasSpec.js
@@ -37,7 +37,7 @@ describe('Canvas draws to page', function() {
     whiteboard.redraw();
 
     var hash = whiteboard.context.hash();
-    expect(hash).equal('f3d47c6b75864dcc174089e89b4e76ce'); // test passes
+    expect(hash).equal('4d003c32d80a1cc3a1b2fcb0ee14f83d'); // test passes
 
     // clear the stack
     whiteboard.context.clear();

--- a/test/canvas/canvasSpec.js
+++ b/test/canvas/canvasSpec.js
@@ -29,10 +29,9 @@ describe('Canvas draws to page', function() {
 
   it('redraw method draws based on user co-ordinates', function() {
     // Add clicks as if user clicked
-    whiteboard.currentStroke = { clickX: [], clickY: [], clickDrag: [] }
+    whiteboard.currentStroke = { clickX: [], clickY: [] }
     whiteboard.currentStroke.clickX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     whiteboard.currentStroke.clickY = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    whiteboard.currentStroke.clickDrag = [false, true, true, true, true, true, true, true, true, false];
 
     // Call the draw function
     whiteboard.redraw();

--- a/test/whiteboard/strokeSpec.js
+++ b/test/whiteboard/strokeSpec.js
@@ -16,10 +16,6 @@ describe('Stroke', function() {
       expect(stroke.clickY).empty;
     })
 
-    it('starts with empty clickDrag array', function() {
-      expect(stroke.clickDrag).empty;
-    })
-
     it('has a default starting colour', function() {
       expect(stroke.colour).equal('#000000')
     })
@@ -46,11 +42,6 @@ describe('Stroke', function() {
     it('adds clicks to the y-axis', function() {
       stroke.addClick(1, 2);
       expect(stroke.clickY[0]).equal(2);
-    })
-
-    it('records whether it is a dragged click', function() {
-      stroke.addClick(1, 2, true);
-      expect(stroke.clickDrag[0]).equal(true);
     })
   })
 })


### PR DESCRIPTION
Click drag array became redundant - Removed in favour of checking during the redraw function whether or not the stroke was a single click