### PR TITLE
Fixing 'Payload too large' bug

### DIFF
--- a/public/src/whiteboard.js
+++ b/public/src/whiteboard.js
@@ -29,21 +29,20 @@ Whiteboard.prototype.stopDrawing = function() {
 
   if (this.currentStroke) {
     this.strokes.push(this.currentStroke);
-
-    $.post('/newstroke', {
-      clickX: this.currentStroke.clickX,
-      clickY: this.currentStroke.clickY,
-      colour: this.currentStroke.colour,
-      fontSize: this.currentStroke.fontSize,
-      whiteboardID: document.location.href.split('/').reverse()[0]
-    })
-
+    this.saveStroke();
     this.currentStroke = null;
   }
 }
 
 Whiteboard.prototype.keepDrawing = function(e, board) {
   if (this.painting) {
+
+    if (this.currentStroke.clickX.length >= 200) {
+      this.saveStroke();
+      this.redraw();
+      this.currentStroke = new Stroke(this.colour, this.fontSize);
+    }
+
     this.currentStroke.addClick(e.pageX - board.offsetLeft, e.pageY - board.offsetTop);
     this.redraw();
   }
@@ -51,6 +50,16 @@ Whiteboard.prototype.keepDrawing = function(e, board) {
 
 Whiteboard.prototype.clear = function() {
   this.context.clearRect(0, 0, this.context.canvas.width, this.context.canvas.height);
+}
+
+Whiteboard.prototype.saveStroke = function() {
+  $.post('/newstroke', {
+    clickX: this.currentStroke.clickX,
+    clickY: this.currentStroke.clickY,
+    colour: this.currentStroke.colour,
+    fontSize: this.currentStroke.fontSize,
+    whiteboardID: document.location.href.split('/').reverse()[0]
+  })
 }
 
 Whiteboard.prototype.redraw = function(stroke) {


### PR DESCRIPTION
adds condition that checks length of clickX and breaks Stroke object into multiple objects, in order to lessen amount of data sent to database at one time